### PR TITLE
Added network permission for macos desktop app

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
I've forgot to add network permission for macos app, so all network request failed. Should be fine from now on.